### PR TITLE
Prune text content

### DIFF
--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -9,8 +9,8 @@ use parse::DOMParseError;
 enum ElementType {
     Root,
     Body,
-    Bold(String),
-    Text(String),
+    Bold(u16),
+    Text(u16),
     Div,
 }
 
@@ -21,7 +21,7 @@ impl FromStr for ElementType {
         match tag {
             "body" => Ok(ElementType::Body),
             "div" => Ok(ElementType::Div),
-            "b" => Ok(ElementType::Bold(String::new())),
+            "b" => Ok(ElementType::Bold(0)),
             _ => todo!("Element tag '{tag}' has not been implemented."),
         }
     }
@@ -43,7 +43,7 @@ struct Element {
 impl Default for Element {
     fn default() -> Self {
         Element {
-            r#type: ElementType::Text(String::new()),
+            r#type: ElementType::Text(0),
             children: vec![],
             attr: "".to_string(),
         }

--- a/src/document/parse.rs
+++ b/src/document/parse.rs
@@ -81,10 +81,13 @@ impl Document {
                     ctx = Some(Element::default());
                     iter.next();
                 }
-                (c, Some(val)) => {
+                (_, Some(val)) => {
                     match &mut val.r#type {
-                        ElementType::Text(inner) => inner.push(*c),
-                        ElementType::Bold(inner) => inner.push(*c),
+                        ElementType::Text(inner) | ElementType::Bold(inner) => {
+                            *inner += 1;
+                            assert!(val.children.len() == 0);
+                            assert!(val.attr.is_empty());
+                        }
                         _ => (),
                     };
                     iter.next();

--- a/src/document/test.rs
+++ b/src/document/test.rs
@@ -1,0 +1,13 @@
+#![allow(unused_imports)]
+use std::fs::File;
+
+use super::{parse::DOMParseError::*, Document};
+
+#[test]
+pub fn unannotated_closing_tag() {
+    let _ = match File::open("./resources/tests/opening_tag_at_EOF.html") {
+        // NOTE(crash): This is just a test case!
+        Ok(file) => Document::new(file).map_err(|err| assert_eq!(err, ClosingTagUnclosed)),
+        Err(_) => unreachable!(),
+    };
+}


### PR DESCRIPTION
This removes text content from being parsed and included in the DOM, as it is irrelevant. We do store the length of the text, but even that could be removed.